### PR TITLE
More resilient GetHashCode implementation

### DIFF
--- a/src/Basic.Generators.UnitTests/AssertEx.cs
+++ b/src/Basic.Generators.UnitTests/AssertEx.cs
@@ -1,0 +1,59 @@
+
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Basic.Generators.UnitTests;
+
+internal static class AssertEx
+{
+    public static void CodeEquals(string expected, string actual)
+    {
+        var expectedReader = new StringReader(expected);
+        var actualReader = new StringReader(actual);
+        var line = 0;
+        do
+        {
+            var expectedLine = expectedReader.ReadLine();
+            var actualLine = actualReader.ReadLine();
+            if (expectedLine is null && actualLine is null)
+            {
+                return;
+            }
+
+            if (expectedLine is null)
+            {
+                Assert.Fail($"Actual has more lines than expected at line {line}: {actualLine}");
+            }
+
+            if (actualLine is null)
+            {
+                Assert.Fail($"Expected has more lines than actual at line {line}: {expectedLine}");
+            }
+
+            Assert.Equal(expectedLine, actualLine);
+            line++;
+        } while (true);
+    }
+
+    public static void Empty(IEnumerable<Diagnostic> diagnostics)
+    {
+        using var e = diagnostics.GetEnumerator();
+        if (!e.MoveNext())
+        {
+            return;
+        }
+
+        var builder = new StringBuilder();
+        do
+        {
+            var diagnostic = e.Current;
+            builder.AppendLine(diagnostic.ToString());
+        } while (e.MoveNext());
+        Assert.Fail(builder.ToString());
+    }
+}

--- a/src/Basic.Generators.UnitTests/AutoEqualityGeneratorUnitTests.cs
+++ b/src/Basic.Generators.UnitTests/AutoEqualityGeneratorUnitTests.cs
@@ -61,13 +61,9 @@ public class AutoEqualityGeneratorUnitTests
                         this.Field == other.Field;
                 }
 
-                public override int GetHashCode()
-                {
-                    var hash = new HashCode();
-                    hash.Add(Field);
-                    return hash.ToHashCode();
-                }
-
+                public override int GetHashCode() =>
+                    HashCode.Combine(
+                        Field);
             }
             """;
 
@@ -114,13 +110,9 @@ public class AutoEqualityGeneratorUnitTests
                         this.Field == other.Field;
                 }
 
-                public override int GetHashCode()
-                {
-                    var hash = new HashCode();
-                    hash.Add(Field);
-                    return hash.ToHashCode();
-                }
-
+                public override int GetHashCode() =>
+                    HashCode.Combine(
+                        Field);
             }
             """;
 
@@ -166,13 +158,9 @@ public class AutoEqualityGeneratorUnitTests
                         this.Field == other.Field;
                 }
 
-                public override int GetHashCode()
-                {
-                    var hash = new HashCode();
-                    hash.Add(Field);
-                    return hash.ToHashCode();
-                }
-
+                public override int GetHashCode() =>
+                    HashCode.Combine(
+                        Field);
             }
             """;
 
@@ -215,7 +203,98 @@ public class AutoEqualityGeneratorUnitTests
             CoreReferences,
             expected,
             generatedTreeIndex: 1);
+    }
 
-        // GeneratorTestUtil.Verify(source, expected, generatedTreeIndex: 1);
+    [Fact]
+    public void GetHashCodeSimple()
+    {
+        var source = """
+            #pragma warning disable CS0649
+
+            [AutoEquality]
+            partial class Simple
+            {
+                int Field1;
+                int Field2;
+            }
+            """;
+
+        var expected = """
+                public override int GetHashCode() =>
+                    HashCode.Combine(
+                        Field1,
+                        Field2);
+            """;
+
+        GeneratorTestUtil.VerifyMethod(
+            "int Simple.GetHashCode()",
+            source,
+            CoreReferences,
+            expected,
+            generatedTreeIndex: 1);
+    }
+
+    [Fact]
+    public void GetHashCodeOldStructFields()
+    {
+        var source = """
+            #pragma warning disable CS0649
+
+            [AutoEquality]
+            partial class Simple
+            {
+                int Field1;
+                int Field2;
+            }
+            """;
+
+        var expected = """
+                public override int GetHashCode()
+                {
+                    int hash = 17;
+                    hash = (hash * 23) + Field1.GetHashCode();
+                    hash = (hash * 23) + Field2.GetHashCode();
+                    return hash;
+                }
+            """;
+
+        GeneratorTestUtil.VerifyMethod(
+            "int Simple.GetHashCode()",
+            source,
+            FrameworkReferences,
+            expected,
+            generatedTreeIndex: 1);
+    }
+
+    [Fact]
+    public void GetHashCodeOldStructClass()
+    {
+        var source = """
+            #pragma warning disable CS0649
+
+            [AutoEquality]
+            partial class Simple
+            {
+                int Field1;
+                string Field2;
+            }
+            """;
+
+        var expected = """
+                public override int GetHashCode()
+                {
+                    int hash = 17;
+                    hash = (hash * 23) + Field1.GetHashCode();
+                    hash = (hash * 23) + (Field2?.GetHashCode() ?? 0);
+                    return hash;
+                }
+            """;
+
+        GeneratorTestUtil.VerifyMethod(
+            "int Simple.GetHashCode()",
+            source,
+            FrameworkReferences,
+            expected,
+            generatedTreeIndex: 1);
     }
 }

--- a/src/Basic.Generators.UnitTests/AutoEqualityGeneratorUnitTests.cs
+++ b/src/Basic.Generators.UnitTests/AutoEqualityGeneratorUnitTests.cs
@@ -1,10 +1,16 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Collections;
+using System.Collections.Generic;
+using Basic.Reference.Assemblies;
+using Microsoft.CodeAnalysis;
 using Xunit;
 
 namespace Basic.Generators.UnitTests;
 
 public class AutoEqualityGeneratorUnitTests
 {
+    public static IEnumerable<MetadataReference> CoreReferences => Net80.References.All;
+    public static IEnumerable<MetadataReference> FrameworkReferences => Net472.References.All;
+
     public GeneratorTestUtil GeneratorTestUtil { get; }
 
     public AutoEqualityGeneratorUnitTests()
@@ -65,7 +71,7 @@ public class AutoEqualityGeneratorUnitTests
             }
             """;
 
-        GeneratorTestUtil.Verify(source, expected, generatedTreeIndex: 1);
+        GeneratorTestUtil.Verify(source, CoreReferences, expected, generatedTreeIndex: 1);
     }
 
     [Fact]
@@ -118,7 +124,7 @@ public class AutoEqualityGeneratorUnitTests
             }
             """;
 
-        GeneratorTestUtil.Verify(source, expected, generatedTreeIndex: 1);
+        GeneratorTestUtil.Verify(source, CoreReferences, expected, generatedTreeIndex: 1);
     }
 
     [Fact]
@@ -170,7 +176,7 @@ public class AutoEqualityGeneratorUnitTests
             }
             """;
 
-        GeneratorTestUtil.Verify(source, expected, generatedTreeIndex: 1);
+        GeneratorTestUtil.Verify(source, CoreReferences, expected, generatedTreeIndex: 1);
     }
 
     [Fact]
@@ -206,6 +212,7 @@ public class AutoEqualityGeneratorUnitTests
         GeneratorTestUtil.VerifyMethod(
             "bool Simple.Equals(Simple? other)",
             source,
+            CoreReferences,
             expected,
             generatedTreeIndex: 1);
 

--- a/src/Basic.Generators.UnitTests/Basic.Generators.UnitTests.csproj
+++ b/src/Basic.Generators.UnitTests/Basic.Generators.UnitTests.csproj
@@ -9,7 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net60"  />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80"  />
+    <PackageReference Include="Basic.Reference.Assemblies.Net472"  />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" >

--- a/src/Basic.Generators.UnitTests/GeneratorTestUtil.cs
+++ b/src/Basic.Generators.UnitTests/GeneratorTestUtil.cs
@@ -21,19 +21,18 @@ public sealed class GeneratorTestUtil
         Generator = generator;
     }
 
-    private Compilation GetCompilation(string sourceCode) =>
-        GetCompilation(new[] { CSharpSyntaxTree.ParseText(sourceCode) });
+    private Compilation GetCompilation(string sourceCode, IEnumerable<MetadataReference> references) =>
+        GetCompilation([CSharpSyntaxTree.ParseText(sourceCode)], references);
 
-    private Compilation GetCompilation(IEnumerable<SyntaxTree> syntaxTrees)
+    private Compilation GetCompilation(IEnumerable<SyntaxTree> syntaxTrees, IEnumerable<MetadataReference> references)
     {
         var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
 
-        var compilation = CSharpCompilation
-            .Create(
-                assemblyName: "TestAssembly",
-                syntaxTrees: syntaxTrees,
-                options: options)
-            .WithReferences(Net60.References.All);
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: syntaxTrees,
+            options: options,
+            references: references);
 
         return compilation;
     }
@@ -46,9 +45,9 @@ public sealed class GeneratorTestUtil
         Assert.Empty(diagnostics);
     }
 
-    public GeneratorDriverRunResult GetRunResult(string sourceCode)
+    public GeneratorDriverRunResult GetRunResult(string sourceCode, IEnumerable<MetadataReference> references)
     {
-        var compilation = GetCompilation(sourceCode);
+        var compilation = GetCompilation(sourceCode, references);
         var driver = CSharpGeneratorDriver.Create(Generator);
         return driver
             .RunGenerators(compilation)
@@ -57,11 +56,12 @@ public sealed class GeneratorTestUtil
 
     private (Compilation Compilation, SyntaxTree GenerateTree) VerifyCore(
         string sourceCode,
+        IEnumerable<MetadataReference> references,
         int generatedTreeIndex = 0)
     {
         var sourceCodeTree = CSharpSyntaxTree.ParseText(sourceCode);
-        var result = GetRunResult(sourceCode);
-        var compilation = GetCompilation(result.GeneratedTrees.Append(sourceCodeTree));
+        var result = GetRunResult(sourceCode, references);
+        var compilation = GetCompilation([.. result.GeneratedTrees, sourceCodeTree], references);
 
         var generatedTree = compilation.SyntaxTrees.ToList()[generatedTreeIndex];
         VerifyNoDiagnostics(compilation);
@@ -70,20 +70,22 @@ public sealed class GeneratorTestUtil
 
     public void Verify(
         string sourceCode,
+        IEnumerable<MetadataReference> references,
         string expectedGeneratedCode,
         int generatedTreeIndex = 0)
     {
-        var (_, generatedTree) = VerifyCore(sourceCode, generatedTreeIndex);
+        var (_, generatedTree) = VerifyCore(sourceCode, references, generatedTreeIndex);
         Assert.Equal(Trim(expectedGeneratedCode), Trim(generatedTree.ToString()));
     }
 
     public void VerifyMethod(
         string methodSignature,
         string sourceCode,
+        IEnumerable<MetadataReference> references,
         string expectedGeneratedCode,
         int generatedTreeIndex = 0)
     {
-        var (compilation, generatedTree) = VerifyCore(sourceCode, generatedTreeIndex);
+        var (compilation, generatedTree) = VerifyCore(sourceCode, references, generatedTreeIndex);
         var semanticModel = compilation.GetSemanticModel(generatedTree);
         var format = new SymbolDisplayFormat();
         var method = generatedTree

--- a/src/Basic.Generators.UnitTests/GeneratorTestUtil.cs
+++ b/src/Basic.Generators.UnitTests/GeneratorTestUtil.cs
@@ -42,7 +42,7 @@ public sealed class GeneratorTestUtil
         var diagnostics = compilation
             .GetDiagnostics()
             .Where(x => x.Severity is DiagnosticSeverity.Error or DiagnosticSeverity.Warning);
-        Assert.Empty(diagnostics);
+        AssertEx.Empty(diagnostics);
     }
 
     public GeneratorDriverRunResult GetRunResult(string sourceCode, IEnumerable<MetadataReference> references)
@@ -75,7 +75,7 @@ public sealed class GeneratorTestUtil
         int generatedTreeIndex = 0)
     {
         var (_, generatedTree) = VerifyCore(sourceCode, references, generatedTreeIndex);
-        Assert.Equal(Trim(expectedGeneratedCode), Trim(generatedTree.ToString()));
+        AssertEx.CodeEquals(Trim(expectedGeneratedCode), Trim(generatedTree.ToString()));
     }
 
     public void VerifyMethod(
@@ -104,7 +104,7 @@ public sealed class GeneratorTestUtil
             })
             .Single();
 
-        Assert.Equal(Trim(expectedGeneratedCode), Trim(method.ToString()));
+        AssertEx.CodeEquals(Trim(expectedGeneratedCode), Trim(method.ToString()));
     }
 
     private static string Trim(string s) => s.Trim(' ', '\n', '\r');

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,8 @@
     <_RoslynVersion>4.11.0</_RoslynVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Basic.Reference.Assemblies.Net60" Version="1.7.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.7.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net472" Version="1.7.9" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(_RoslynVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(_RoslynVersion)" />


### PR DESCRIPTION
Handle the case where `System.HashCode` is not available.